### PR TITLE
set initial score to 0 on new tasks

### DIFF
--- a/src/app/components/tasks/task-tree/task-tree.component.ts
+++ b/src/app/components/tasks/task-tree/task-tree.component.ts
@@ -57,6 +57,7 @@ const BLANK_TASK: Task = {
   iterations: 1,
   iterationTermination: TaskIterationTermination.IterationCount,
   triggerCondition: TaskTrigger.Manual,
+  score: 0,
 };
 
 @Component({


### PR DESCRIPTION
- avoids error on creation if the user didn't manually update the score