### PR TITLE
Fix Scenario Templates layout and admin edit dialog save handlers

### DIFF
--- a/src/app/components/admin/admin-scenario-templates/admin-scenario-templates.component.html
+++ b/src/app/components/admin/admin-scenario-templates/admin-scenario-templates.component.html
@@ -4,5 +4,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 
 <app-scenario-template-list class="background" fxFill fxLayout="row" fxLayoutAlign="center start"
-  [isLoading]="loading$ | async" [scenarioTemplateList]="scenarioTemplates$ | async" [adminMode]="true">
+  [isLoading]="loading$ | async" [scenarioTemplateList]="scenarioTemplates$ | async" [adminMode]="true"
+  (saveScenarioTemplate)="saveScenarioTemplate($event)">
 </app-scenario-template-list>

--- a/src/app/components/admin/admin-scenario-templates/admin-scenario-templates.component.ts
+++ b/src/app/components/admin/admin-scenario-templates/admin-scenario-templates.component.ts
@@ -6,6 +6,7 @@ Copyright 2024 Carnegie Mellon University. All Rights Reserved.
 import { Component, OnInit } from '@angular/core';
 import { ScenarioTemplateDataService } from 'src/app/data/scenario-template/scenario-template-data.service';
 import { ScenarioTemplateQuery } from 'src/app/data/scenario-template/scenario-template.query';
+import { ScenarioTemplate } from 'src/app/generated/steamfitter.api';
 
 @Component({
     selector: 'app-admin-scenario-templates',
@@ -24,5 +25,13 @@ export class AdminScenarioTemplatesComponent implements OnInit {
 
   ngOnInit(): void {
     this.scenarioTemplateDataService.load();
+  }
+
+  saveScenarioTemplate(scenarioTemplate: ScenarioTemplate) {
+    if (!scenarioTemplate.id) {
+      this.scenarioTemplateDataService.add(scenarioTemplate);
+    } else {
+      this.scenarioTemplateDataService.updateScenarioTemplate(scenarioTemplate);
+    }
   }
 }

--- a/src/app/components/admin/admin-scenarios/admin-scenarios.component.html
+++ b/src/app/components/admin/admin-scenarios/admin-scenarios.component.html
@@ -5,5 +5,5 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
 <app-scenario-list class="background" fxFill fxLayout="row" fxLayoutAlign="center start"
   [isLoading]="loading$ | async" [scenarioList]="scenarios$ | async" [statuses]="statuses | async" [adminMode]="true"
-  [views]="viewList | async">
+  [views]="viewList | async" (saveScenario)="saveScenario($event)">
 </app-scenario-list>

--- a/src/app/components/admin/admin-scenarios/admin-scenarios.component.ts
+++ b/src/app/components/admin/admin-scenarios/admin-scenarios.component.ts
@@ -10,6 +10,7 @@ import { ScenarioDataService } from 'src/app/data/scenario/scenario-data.service
 import { ScenarioQuery } from 'src/app/data/scenario/scenario.query';
 import { PlayerDataService } from 'src/app/data/player/player-data-service';
 import { ActivatedRoute } from '@angular/router';
+import { Scenario } from 'src/app/generated/steamfitter.api';
 
 @Component({
     selector: 'app-admin-scenarios',
@@ -37,5 +38,13 @@ export class AdminScenariosComponent implements OnInit {
 
   ngOnInit(): void {
     this.scenarioDataService.load();
+  }
+
+  saveScenario(scenario: Scenario) {
+    if (!scenario.id) {
+      this.scenarioDataService.add(scenario);
+    } else {
+      this.scenarioDataService.updateScenario(scenario);
+    }
   }
 }

--- a/src/app/components/scenario-templates/scenario-template-list/scenario-template-list.component.html
+++ b/src/app/components/scenario-templates/scenario-template-list/scenario-template-list.component.html
@@ -41,7 +41,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </ng-container>
 
   <ng-container matColumnDef="durationHours">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>Duration</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Duration (Hours)</th>
     <td mat-cell *matCellDef="let element">{{ element.durationHours }}</td>
   </ng-container>
 

--- a/src/app/components/scenario-templates/scenario-templates.component.scss
+++ b/src/app/components/scenario-templates/scenario-templates.component.scss
@@ -13,11 +13,6 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  min-width: 900px;
-  margin-top: 40px;
-  margin-left: 40px;
-  margin-right: 40px;
-  margin-bottom: 40px;
 }
 
 .add-margin {
@@ -32,6 +27,8 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .title {
@@ -39,7 +36,7 @@
 }
 
 .full-width {
-  width: 70%;
+  width: 100%;
 }
 
 .add-margin {


### PR DESCRIPTION
  ## Summary
  - Fix Scenario Templates section to match Scenarios layout (full-width, consistent margins/padding)                                                                                       
  - Add "(Hours)" unit label to Duration column header to match Alloy convention
  - Wire up missing `saveScenario` and `saveScenarioTemplate` output bindings on admin pages — edit dialog changes were silently discarded because no handler was bound

  ## Test plan
  - [ ] Verify My Scenario Templates header width matches My Scenarios
  - [ ] Verify Duration column shows "Duration (Hours)"
  - [ ] Admin > Scenarios: edit a scenario name via dialog, confirm it persists
  - [ ] Admin > Scenario Templates: edit a template name via dialog, confirm it persists