### PR TITLE
Add cancelled status icon and disable execute on non-active scenarios

### DIFF
--- a/src/app/components/tasks/manual-tasks/manual-tasks-list/manual-tasks-list.component.html
+++ b/src/app/components/tasks/manual-tasks/manual-tasks-list/manual-tasks-list.component.html
@@ -36,7 +36,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <td class="icon-cell">
             <mat-icon
               [fontIcon]="statusIcon(task.totalStatus == 'none' ? 'manual' : task.totalStatus)"
-              matTooltip="{{ task.totalStatus == 'none' ? 'click to execute' : task.totalStatus }}"
+              matTooltip="{{ task.totalStatus == 'none' ? 'pending' : task.totalStatus }}"
             ></mat-icon>
           </td>
           @if (scenario?.score > 0) {
@@ -47,14 +47,15 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
             </td>
           }
           <td class="action-cell">
-            <button
-              mat-icon-button
-              [disabled]="!task.executable"
-              (click)="executeTask(task)"
-              [matTooltip]="task.executable ? task.description : 'This Task cannot be executed again once successful'"
-              >
-              <mat-icon fontIcon="mdi-play"></mat-icon>
-            </button>
+            <span [matTooltip]="scenario?.status !== 'active' ? 'Scenario is not active' : !task.executable ? 'This Task cannot be executed again once successful' : task.description">
+              <button
+                mat-icon-button
+                [disabled]="!task.executable || scenario?.status !== 'active'"
+                (click)="executeTask(task)"
+                >
+                <mat-icon fontIcon="mdi-play"></mat-icon>
+              </button>
+            </span>
             <span matTooltip="{{ task.description }}">{{ task.name }}</span>
           </td>
         </tr>

--- a/src/app/components/tasks/manual-tasks/manual-tasks-list/manual-tasks-list.component.ts
+++ b/src/app/components/tasks/manual-tasks/manual-tasks-list/manual-tasks-list.component.ts
@@ -46,6 +46,7 @@ export class ManualTasksListComponent implements OnInit {
     queued: 'mdi-clock-time-three-outline',
     sent: 'mdi-send',
     time: 'mdi-alarm',
+    cancelled: 'mdi-cancel',
   };
 
   statusIcon(status: string): string {

--- a/src/app/components/tasks/task-tree/task-tree.component.ts
+++ b/src/app/components/tasks/task-tree/task-tree.component.ts
@@ -470,6 +470,7 @@ export class TaskTreeComponent implements OnInit, OnDestroy {
     queued: 'mdi-clock-time-three-outline',
     sent: 'mdi-send',
     time: 'mdi-alarm',
+    cancelled: 'mdi-cancel',
   };
 
   statusIcon(status: string): string {


### PR DESCRIPTION
  Body:                                                                                                                                                                                                                                                                                
  ## Summary                              
  - Add `mdi-cancel` icon mapping for cancelled task status — previously showed fallback question mark icon                                                                                                                                                                            
  - Disable task execute button when scenario is not active, with tooltip explaining why                                                                                                                                                                                             
  - Fix misleading status icon tooltip from "click to execute" to "pending" for unexecuted tasks

  ## Test plan
  - [ ] Cancelled tasks show cancel icon instead of question mark
  - [ ] Execute button is disabled on ended/ready scenarios
  - [ ] Hovering disabled execute button shows "Scenario is not active"
  - [ ] Execute button works normally on active scenarios