### PR TITLE
Fix ESLint config and swagger generator version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
     "rules": {
         "@angular-eslint/component-class-suffix": "error",
         "@angular-eslint/directive-class-suffix": "error",
-        "@angular-eslint/no-host-metadata-property": "error",
         "@angular-eslint/no-input-rename": "error",
         "@angular-eslint/no-inputs-metadata-property": "error",
         "@angular-eslint/no-output-on-prefix": "error",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "ng test",
     "lint": "eslint -c .eslintrc.js --ext .ts src/",
     "e2e": "ng e2e",
-    "swagger-gen": "curl --insecure http://host.docker.internal:4400/swagger/v1/swagger.json --output swagger.json && node_modules/@openapitools/openapi-generator-cli/bin/openapi-generator generate -i ./swagger.json -g typescript-angular -o src/app/generated/steamfitter.api --additional-properties ngVersion=11.2.1 --additional-properties useRxJS6=true --additional-properties modelPropertyNaming=original --type-mappings=DateTime=Date --skip-validate-spec",
-    "swagger-gen-win": "docker run --rm -v %CD%:/local openapitools/openapi-generator-cli:v5.1.0 generate -i http://host.docker.internal:4400/swagger/v1/swagger.json -g typescript-angular -o /local/src/app/generated/steamfitter.api --additional-properties ngVersion=11.2.1 --additional-properties useRxJS6=true --additional-properties modelPropertyNaming=original --type-mappings=DateTime=Date --skip-validate-spec"
+    "swagger-gen": "curl --insecure http://host.docker.internal:4400/swagger/v1/swagger.json --output swagger.json && node_modules/@openapitools/openapi-generator-cli/bin/openapi-generator generate -i ./swagger.json -g typescript-angular -o src/app/generated/steamfitter.api --additional-properties ngVersion=21.2.1 --additional-properties useRxJS6=true --additional-properties modelPropertyNaming=original --type-mappings=DateTime=Date --skip-validate-spec",
+    "swagger-gen-win": "docker run --rm -v %CD%:/local openapitools/openapi-generator-cli:v5.1.0 generate -i http://host.docker.internal:4400/swagger/v1/swagger.json -g typescript-angular -o /local/src/app/generated/steamfitter.api --additional-properties ngVersion=21.2.1 --additional-properties useRxJS6=true --additional-properties modelPropertyNaming=original --type-mappings=DateTime=Date --skip-validate-spec"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
  Body:
  ## Summary
  - Remove deprecated `@angular-eslint/no-host-metadata-property` rule that was removed in @angular-eslint v21, causing all lint runs to fail with "Definition for rule not found"
  - Update swagger-gen scripts from ngVersion=11.2.1 to 21.2.1 to match the actual Angular version

  ## Test plan
  - [x] `npm run lint` runs without "definition not found" errors
  - [x] `npm run build` succeeds
  - [ ] Verify swagger regeneration produces compatible code (if needed)