### PR TITLE
Support helm chart settings updates in workflow

### DIFF
--- a/.github/workflows/update-helm-chart.yml
+++ b/.github/workflows/update-helm-chart.yml
@@ -16,3 +16,5 @@ jobs:
           github_app_private_key: ${{ secrets.CRUCIBLE_HELM_UPDATE_PRIVATE_KEY }}
           chart_file: charts/steamfitter/charts/steamfitter-ui/Chart.yaml
           parent_chart_file: charts/steamfitter/Chart.yaml
+          settings_file: src/assets/config/settings.json
+          settings_file_kind: angular-settings


### PR DESCRIPTION
Add `settings_file` and `settings_file_kind` inputs to wire up the settings-sync phase introduced in Crucible-Github-Actions. When a new release is published, the action will now diff the app settings file between release tags and propagate added/removed keys into the helm chart values.